### PR TITLE
Model rollouts for training and inference

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,11 @@
 # TODO 
 
-- [ ] benchmark new dataloader
-- [ ] model roll-outs (training)
+- [x] stable conda-env on Atos that we can all use
+- [x] allow the user to select plevs when creating the dataset
+- [x] benchmark new dataloader
+- [x] model roll-outs (training)
 - [ ] inference (with roll-outs)
-- [ ] stable conda-env on Atos that we can all use
-- [ ] allow the user to select plevs when creating the dataset
 - [ ] inspect input data
 - [ ] check training and validation errors
 - [ ] split config file into two separate files (model-specific config and file paths)
+- [ ] check if we're properly using pinned memory https://pytorch.org/docs/stable/data.html#memory-pinning

--- a/TODO.md
+++ b/TODO.md
@@ -4,8 +4,11 @@
 - [x] allow the user to select plevs when creating the dataset
 - [x] benchmark new dataloader
 - [x] model roll-outs (training)
-- [ ] inference (with roll-outs)
+- [x] inference (with roll-outs)
+- [x] check if we're properly using pinned memory https://pytorch.org/docs/stable/data.html#memory-pinning
+- [x] activation checkpointing
+    - Reduce memory usage at the expense of additional (re-)computation during the backward pass.
+    - https://github.com/prigoyal/pytorch_memonger/blob/master/tutorial/Checkpointing_for_PyTorch_models.ipynb
 - [ ] inspect input data
 - [ ] check training and validation errors
 - [ ] split config file into two separate files (model-specific config and file paths)
-- [ ] check if we're properly using pinned memory https://pytorch.org/docs/stable/data.html#memory-pinning

--- a/graph_weather/config/wb_config_atos.yaml
+++ b/graph_weather/config/wb_config_atos.yaml
@@ -12,7 +12,9 @@ input:
       filename-template: "pl_*.nc"
     test:
       basedir: /ec/res4/hpcperm/syma/WeatherBench/netcdf/test
-      filename-template: "pl_*.nc"      
+      filename-template: "pl_*.nc"
+    prediction:
+      filename: /ec/res4/hpcperm/syma/WeatherBench/netcdf/test/pl_2020.nc
     names:
       - z
       - t
@@ -68,8 +70,8 @@ model:
       batch-size: 1
       batch-chunk-size: 1
     inference:
-      batch-size: 2
-      batch-chunk-size: 2
+      batch-size: 1
+      batch-chunk-size: 8
 
   # miscellaneous
   precision: 16
@@ -77,14 +79,14 @@ model:
   # runs only N training batches [N = integer | null]
   # if null then we run through all the batches
   limit-batches:
-    train: 25
-    valid: 25
-    test: 25
-    predict: 25
+    training: null
+    validation: null
+    test: 50
+    predict: 50
 
   # specific GNN model settings
   lead-time: 6
-  max-epochs: 1
+  max-epochs: 15
   learn-rate: 1.e-3
   hidden-dim: 64
   num-blocks: 3

--- a/graph_weather/config/wb_config_atos.yaml
+++ b/graph_weather/config/wb_config_atos.yaml
@@ -73,12 +73,12 @@ model:
       training: 4
       validation: 2
       inference: 4
-    training:
-      batch-size: 1
-      batch-chunk-size: 1
-    inference:
-      batch-size: 1
-      batch-chunk-size: 8
+    batch-size:
+      training: 1
+      inference: 2
+    batch-chunk-size:
+      training: 1
+      inference: 4
 
   # miscellaneous
   precision: 16

--- a/graph_weather/config/wb_config_atos.yaml
+++ b/graph_weather/config/wb_config_atos.yaml
@@ -31,14 +31,19 @@ input:
 #  OUTPUT BLOCK
 ###################
 output:
-  basedir: /ec/res4/scratch/syma/GNN/WeatherBench/checkpoints
+  basedir: /ec/res4/scratch/syma/GNN/WeatherBench
   logging:
     log-dir: /ec/res4/scratch/syma/GNN/WeatherBench/logs
-    log-interval: 50
+    log-interval: 25
+  checkpoints:
+    ckpt-dir: checkpoints
   model:
-    save-top-k: 3
+    save-top-k: 1
     checkpoint-filename: "gnn-wb-weights-{epoch:02d}-{val_wmse:.3f}"
 
+###################
+#  MODEL BLOCK
+###################
 model:
   debug:
     # this will detect and trace back NaNs / Infs etc. but will slow down training
@@ -49,25 +54,38 @@ model:
     enabled: False
   dask:
     enabled: True
-    temp-dir: /ec/res4/scratch/syma/dask-temp-dir
+    temp-dir: /ec/res4/scratch/syma/GNN/WeatherBench/dask-temp-dir
+    log-dir: /ec/res4/scratch/syma/GNN/WeatherBench/dask-log-dir
     trim-worker-memory: True
     num-workers: 16
     num-threads-per-worker: 2
     persist-data: False
-    dashboard-port: 9988
+    dashboard-port: 8787
+    scheduler-port: 8786
   dataloader:
-    num-workers: 16
+    num-workers: 6
     batch-size: 1
-    batch-chunk-size: 3
+    batch-chunk-size: 1
+
   # miscellaneous
   precision: 16
   fast-dev-run: False
   # runs only N training batches [N = integer | null]
   # if null then we run through all the batches
-  limit-train-batches: null
+  limit-train-batches: 25
+  limit-val-batches: 25
+  limit-test-batches: 25
+
   # specific GNN model settings
   lead-time: 6
   max-epochs: 1
-  learn-rate: 2.e-3
+  learn-rate: 1.e-3
   hidden-dim: 64
   num-blocks: 3
+  # length of the "rollout" window (see Keisler's paper)
+  rollout: 4
+  # Keisler's three training rounds were:
+  # Round 1. ~960,000 batches @ ~0.3 seconds per batch (4-step rollout)
+  # Round 2. ~90,000 batches @ ~1.0 seconds per batch (8-step rollout)
+  # Round 3. ~70,000 batches @ ~1.5 seconds per batch (12-step rollout)
+  # Each batch is an N-step rollout, with batch_size=1

--- a/graph_weather/config/wb_config_atos.yaml
+++ b/graph_weather/config/wb_config_atos.yaml
@@ -51,7 +51,7 @@ model:
     # this will detect and trace back NaNs / Infs etc. but will slow down training
     anomaly-detection: False
   wandb:
-    enabled: True
+    enabled: False
   tensorboard:
     enabled: False
   dask:
@@ -65,7 +65,10 @@ model:
     dashboard-port: 8787
     scheduler-port: 8786
   dataloader:
-    num-workers: 6
+    num-workers:
+      training: 8
+      validation: 2
+      inference: 4
     training:
       batch-size: 1
       batch-chunk-size: 1
@@ -79,14 +82,14 @@ model:
   # runs only N training batches [N = integer | null]
   # if null then we run through all the batches
   limit-batches:
-    training: null
-    validation: null
+    training: 200
+    validation: 50
     test: 50
     predict: 50
 
   # specific GNN model settings
   lead-time: 6
-  max-epochs: 15
+  max-epochs: 2
   learn-rate: 1.e-3
   hidden-dim: 64
   num-blocks: 3

--- a/graph_weather/config/wb_config_atos.yaml
+++ b/graph_weather/config/wb_config_atos.yaml
@@ -1,15 +1,20 @@
 input:
+  format: zarr  # or "netcdf4"
   variables:
     training:
-      basedir: /ec/res4/hpcperm/syma/WeatherBench/netcdf/training
-      filename-template: "pl_*.nc"
+      # basedir: /ec/res4/hpcperm/syma/WeatherBench/netcdf/training
+      # filename-template: "pl_*.nc"
+      basedir: /ec/res4/scratch/syma/data/WeatherBench/zarr/training
+      filename-template: "pl_*.zarr"
       summary-stats:
         precomputed: True
         means: /ec/res4/hpcperm/syma/WeatherBench/netcdf/means-1979-2015.nc
         std-devs: /ec/res4/hpcperm/syma/WeatherBench/netcdf/sds-1979-2015.nc
     validation:
-      basedir: /ec/res4/hpcperm/syma/WeatherBench/netcdf/validation
-      filename-template: "pl_*.nc"
+      # basedir: /ec/res4/hpcperm/syma/WeatherBench/netcdf/validation
+      # filename-template: "pl_*.nc"
+      basedir: /ec/res4/scratch/syma/data/WeatherBench/zarr/validation
+      filename-template: "pl_*.zarr"
     test:
       basedir: /ec/res4/hpcperm/syma/WeatherBench/netcdf/test
       filename-template: "pl_*.nc"
@@ -59,14 +64,13 @@ model:
     temp-dir: /ec/res4/scratch/syma/GNN/WeatherBench/dask-temp-dir
     log-dir: /ec/res4/scratch/syma/GNN/WeatherBench/dask-log-dir
     trim-worker-memory: True
-    num-workers: 16
-    num-threads-per-worker: 2
-    persist-data: False
+    num-workers: 8
+    num-threads-per-worker: 1
     dashboard-port: 8787
     scheduler-port: 8786
   dataloader:
     num-workers:
-      training: 8
+      training: 4
       validation: 2
       inference: 4
     training:

--- a/graph_weather/config/wb_config_atos.yaml
+++ b/graph_weather/config/wb_config_atos.yaml
@@ -64,17 +64,23 @@ model:
     scheduler-port: 8786
   dataloader:
     num-workers: 6
-    batch-size: 1
-    batch-chunk-size: 1
+    training:
+      batch-size: 1
+      batch-chunk-size: 1
+    inference:
+      batch-size: 2
+      batch-chunk-size: 2
 
   # miscellaneous
   precision: 16
   fast-dev-run: False
   # runs only N training batches [N = integer | null]
   # if null then we run through all the batches
-  limit-train-batches: 25
-  limit-val-batches: 25
-  limit-test-batches: 25
+  limit-batches:
+    train: 25
+    valid: 25
+    test: 25
+    predict: 25
 
   # specific GNN model settings
   lead-time: 6

--- a/graph_weather/config/wb_config_ewc.yaml
+++ b/graph_weather/config/wb_config_ewc.yaml
@@ -30,10 +30,11 @@ input:
 #  OUTPUT BLOCK
 ###################
 output:
-  basedir: /data2/malexe/scratch/GNN/WeatherBench/checkpoints
+  basedir: /data2/malexe/scratch/GNN/WeatherBench
   logging:
     log-dir: /data2/malexe/scratch/GNN/WeatherBench/logs
     log-interval: 25
+  ckpt-dir: checkpoints
   model:
     save-top-k: 3
     checkpoint-filename: "gnn-wb-weights-{epoch:02d}-{val_wmse:.3f}"
@@ -61,7 +62,11 @@ model:
   # miscellaneous
   precision: 16
   fast-dev-run: False
-  limit-train-batches: 100
+  limit-batches:
+    train: 100
+    valid: 100
+    test: 100
+    predict: 100
   # specific GNN model settings
   lead-time: 6
   max-epochs: 1

--- a/graph_weather/data/wb_constants.py
+++ b/graph_weather/data/wb_constants.py
@@ -9,7 +9,7 @@ class WeatherBenchConstantFields:
         self,
         const_fname: str,
         const_names: Optional[List[str]] = None,
-        batch_chunk_size: int = 8,
+        batch_chunk_size: int = 4,
     ) -> None:
         """
         Args:

--- a/graph_weather/data/wb_datamodule.py
+++ b/graph_weather/data/wb_datamodule.py
@@ -24,11 +24,12 @@ LOGGER = get_logger(__name__)
 
 class WeatherBenchDataBatch:
     """Custom batch type for WeatherBench data."""
+
     def __init__(self, batch_data: List[Tuple[np.ndarray, np.ndarray]], const_data: np.ndarray) -> None:
         """Construct a batch object from the variable and constant data tensors."""
         zipped_batch = list(zip(*batch_data))
         batch: List[torch.Tensor] = []
-        
+
         for X in zipped_batch:
             X = torch.as_tensor(
                 np.concatenate(

--- a/graph_weather/data/wb_datamodule.py
+++ b/graph_weather/data/wb_datamodule.py
@@ -64,7 +64,7 @@ def get_weatherbench_dataset(fnames: List[str], config: YAMLConfig, scheduler_ad
 class WeatherBenchTrainingDataModule(pl.LightningDataModule):
     def __init__(self, config: YAMLConfig, scheduler_address: Optional[str] = None) -> None:
         super().__init__()
-        self.batch_size = config["model:dataloader:batch-size"]
+        self.batch_size = config["model:dataloader:training:batch-size"]
         self.num_workers = config["model:dataloader:num-workers"]
         self.config = config
 
@@ -84,7 +84,7 @@ class WeatherBenchTrainingDataModule(pl.LightningDataModule):
             var_sd=var_sds,
             plevs=config["input:variables:levels"],
             lead_time=config["model:lead-time"],
-            batch_chunk_size=config["model:dataloader:batch-chunk-size"],
+            batch_chunk_size=config["model:dataloader:train:batch-chunk-size"],
             rollout=config["model:rollout"],
         )
 
@@ -98,28 +98,14 @@ class WeatherBenchTrainingDataModule(pl.LightningDataModule):
             var_sd=var_sds,
             plevs=config["input:variables:levels"],
             lead_time=config["model:lead-time"],
-            batch_chunk_size=config["model:dataloader:batch-chunk-size"],
-            rollout=config["model:rollout"],
-        )
-
-        self.ds_test = WeatherBenchDataset(
-            fnames=glob.glob(
-                os.path.join(config["input:variables:test:basedir"], config["input:variables:test:filename-template"])
-            ),
-            var_names=config["input:variables:names"],
-            read_wb_data_func=partial(get_weatherbench_dataset, config=config, scheduler_address=scheduler_address),
-            var_mean=var_means,
-            var_sd=var_sds,
-            plevs=config["input:variables:levels"],
-            lead_time=config["model:lead-time"],
-            batch_chunk_size=config["model:dataloader:batch-chunk-size"],
+            batch_chunk_size=config["model:dataloader:train:batch-chunk-size"],
             rollout=config["model:rollout"],
         )
 
         self.const_data = WeatherBenchConstantFields(
             const_fname=config["input:constants:filename"],
             const_names=config["input:constants:names"],
-            batch_chunk_size=config["model:dataloader:batch-chunk-size"],
+            batch_chunk_size=config["model:dataloader:train:batch-chunk-size"],
         )
 
     def _calculate_summary_statistics(self, dask_cluster_address: Optional[str] = None) -> Tuple[xr.Dataset, xr.Dataset]:
@@ -189,7 +175,7 @@ class WeatherBenchTrainingDataModule(pl.LightningDataModule):
 class WeatherBenchTestDataModule(pl.LightningDataModule):
     def __init__(self, config: YAMLConfig, scheduler_address: Optional[str] = None) -> None:
         super().__init__()
-        self.batch_size = config["model:dataloader:batch-size"]
+        self.batch_size = config["model:dataloader:inference:batch-size"]
         self.num_workers = config["model:dataloader:num-workers"]
         self.config = config
 
@@ -206,14 +192,14 @@ class WeatherBenchTestDataModule(pl.LightningDataModule):
             var_sd=var_sds,
             plevs=config["input:variables:levels"],
             lead_time=config["model:lead-time"],
-            batch_chunk_size=config["model:dataloader:batch-chunk-size"],
+            batch_chunk_size=config["model:dataloader:inference:batch-chunk-size"],
             rollout=config["model:rollout"],
         )
 
         self.const_data = WeatherBenchConstantFields(
             const_fname=config["input:constants:filename"],
             const_names=config["input:constants:names"],
-            batch_chunk_size=config["model:dataloader:batch-chunk-size"],
+            batch_chunk_size=config["model:dataloader:inference:batch-chunk-size"],
         )
 
     def _load_summary_statistics(self) -> Tuple[xr.Dataset, xr.Dataset]:

--- a/graph_weather/data/wb_datamodule.py
+++ b/graph_weather/data/wb_datamodule.py
@@ -76,6 +76,8 @@ def _custom_collator_wrapper(const_data: np.ndarray) -> Callable:
 
 def get_weatherbench_dataset(fnames: List[str], config: YAMLConfig, scheduler_address: Optional[str] = None) -> xr.Dataset:
     client: Optional[Client] = init_dask_client(scheduler_address, config) if scheduler_address is not None else None
+    if client is not None:
+        LOGGER.debug("Created Dask client %s attached to %s ...", client, scheduler_address)
     return xr.open_mfdataset(
         fnames,
         parallel=(client is not None),  # uses Dask if a client is present

--- a/graph_weather/data/wb_dataset.py
+++ b/graph_weather/data/wb_dataset.py
@@ -89,7 +89,7 @@ class WeatherBenchDataset(IterableDataset):
                 name=f"cluster_for_dataloader_worker_{worker_info.id:02d}",
                 n_workers=num_dask_workers,
                 threads_per_worker=num_dask_threads_per_worker,
-                memory_limit="4GB",  # this is per worker; TODO: get rid of this hardcoded value
+                memory_limit="16GB",  # this is per worker; TODO: get rid of this hardcoded value
                 processes=False,
             )
             self.client = Client(self.cluster)

--- a/graph_weather/data/wb_dataset.py
+++ b/graph_weather/data/wb_dataset.py
@@ -116,10 +116,9 @@ class WeatherBenchDataset(IterableDataset):
         if worker_info is None:
             LOGGER.error("worker_info is None! Set num_workers > 0 in your dataloader!")
             raise RuntimeError
-        else:
-            worker_id = worker_info.id
-            low = worker_id * self.n_chunks_per_worker
-            high = min((worker_id + 1) * self.n_chunks_per_worker, self.ds_len)
+        worker_id = worker_info.id
+        low = worker_id * self.n_chunks_per_worker
+        high = min((worker_id + 1) * self.n_chunks_per_worker, self.ds_len)
 
         chunk_index_range = np.arange(low, high, dtype=np.uint32)
         shuffled_chunk_indices = self.rng.choice(chunk_index_range, size=self.n_chunks_per_worker, replace=False)
@@ -156,11 +155,10 @@ def worker_init_func(worker_id: int, dask_temp_dir: str, num_dask_workers: int, 
     if worker_info is None:
         LOGGER.error("worker_info is None! Set num_workers > 0 in your dataloader!")
         raise RuntimeError
-    else:
-        dataset_obj = worker_info.dataset  # the copy of the dataset held by this worker process.
-        dataset_obj.per_worker_init(
-            n_workers=worker_info.num_workers,
-            dask_temp_dir=dask_temp_dir,
-            num_dask_workers=num_dask_workers,
-            num_dask_threads_per_worker=num_dask_threads_per_worker,
-        )
+    dataset_obj = worker_info.dataset  # the copy of the dataset held by this worker process.
+    dataset_obj.per_worker_init(
+        n_workers=worker_info.num_workers,
+        dask_temp_dir=dask_temp_dir,
+        num_dask_workers=num_dask_workers,
+        num_dask_threads_per_worker=num_dask_threads_per_worker,
+    )

--- a/graph_weather/data/wb_dataset.py
+++ b/graph_weather/data/wb_dataset.py
@@ -113,7 +113,7 @@ class WeatherBenchDataset(IterableDataset):
                 # -> shape: (bs, nvar, nlev, lat, lon)
                 X = da.stack([X_[var] for var in self.vars], axis=1)
                 batch.append(X)
-                idx = np.arange(start, end, dtype=np.int32) 
+                idx = np.arange(start, end, dtype=np.int32)
                 batch_idx.append(idx)
 
             yield tuple(batch), tuple(batch_idx)

--- a/graph_weather/models/analysis.py
+++ b/graph_weather/models/analysis.py
@@ -103,5 +103,5 @@ class GraphWeatherAssimilator(nn.Module, PyTorchModelHubMixin):
         """
         x, edge_idx, edge_attr = self.encoder(features, obs_lat_lon_heights)
         x = self.processor(x, edge_idx, edge_attr)
-        x = self.decoder(x, features.shape[0])
+        x = self.decoder(x, features)
         return x

--- a/graph_weather/models/forecast.py
+++ b/graph_weather/models/forecast.py
@@ -102,5 +102,5 @@ class GraphWeatherForecaster(nn.Module, PyTorchModelHubMixin):
         """
         x, edge_idx, edge_attr = self.encoder(features)
         x = self.processor(x, edge_idx, edge_attr)
-        x = self.decoder(x, features.shape[0])
+        x = self.decoder(x, features)
         return x

--- a/graph_weather/models/forecast.py
+++ b/graph_weather/models/forecast.py
@@ -53,6 +53,7 @@ class GraphWeatherForecaster(nn.Module, PyTorchModelHubMixin):
                 one of 'LayerNorm', 'GraphNorm', 'InstanceNorm', 'BatchNorm', 'MessageNorm', or None
         """
         super().__init__()
+        self.feature_dim = feature_dim
         self.encoder = Encoder(
             lat_lons=lat_lons,
             resolution=resolution,
@@ -102,5 +103,5 @@ class GraphWeatherForecaster(nn.Module, PyTorchModelHubMixin):
         """
         x, edge_idx, edge_attr = self.encoder(features)
         x = self.processor(x, edge_idx, edge_attr)
-        x = self.decoder(x, features)
+        x = self.decoder(x, features[..., : self.feature_dim])
         return x

--- a/graph_weather/models/layers/assimilator_decoder.py
+++ b/graph_weather/models/layers/assimilator_decoder.py
@@ -97,6 +97,7 @@ class AssimilatorDecoder(torch.nn.Module):
 
         # Use normal graph as its a bit simpler
         self.graph = Data(x=nodes, edge_index=edge_index, edge_attr=self.h3_to_lat_distances)
+        # self.register_buffer("graph", graph, persistent=False)
 
         self.edge_encoder = MLP(2, output_edge_dim, hidden_dim_processor_edge, 2, mlp_norm_type)
         self.graph_processor = GraphProcessor(

--- a/graph_weather/models/layers/decoder.py
+++ b/graph_weather/models/layers/decoder.py
@@ -82,6 +82,6 @@ class Decoder(AssimilatorDecoder):
         Returns:
             Updated features for model
         """
-        out = super().forward(processor_features, start_features)
+        out = super().forward(processor_features, start_features.shape[0])
         out = out + start_features  # residual connection
         return out

--- a/graph_weather/models/layers/gnn_blocks.py
+++ b/graph_weather/models/layers/gnn_blocks.py
@@ -95,6 +95,7 @@ import torch
 from torch import nn
 from torch_geometric.nn import MetaLayer
 from torch_scatter import scatter_sum
+from torch.utils.checkpoint import checkpoint
 
 
 class MLP(nn.Module):
@@ -150,7 +151,8 @@ class MLP(nn.Module):
         Returns:
             The transformed tensor
         """
-        return self.model(x)
+        out = checkpoint(self.model, x, use_reentrant=False)
+        return out
 
 
 #############################

--- a/graph_weather/predict/wb_predict.py
+++ b/graph_weather/predict/wb_predict.py
@@ -46,7 +46,9 @@ def _reshape_predictions(predictions: torch.Tensor, config: YAMLConfig) -> torch
     )
 
 
-def store_predictions(predictions: torch.Tensor, ds_test: xr.Dataset, config: YAMLConfig, dask_scheduler_address: Optional[str] = None) -> None:
+def store_predictions(
+    predictions: torch.Tensor, ds_test: xr.Dataset, config: YAMLConfig, dask_scheduler_address: Optional[str] = None
+) -> None:
     """
     Stores the model predictions into a netCDF file.
     Args:
@@ -55,10 +57,8 @@ def store_predictions(predictions: torch.Tensor, ds_test: xr.Dataset, config: YA
         config: job configuration
         dask_scheduler_address: dask scheduler address. if not None then we create a Dask client and have it save the data.
     """
-    
 
     # then create a new xarray Dataset with the same coordinates, plus the rollout
-
 
 
 def backtransform_predictions(predictions: torch.Tensor, means: xr.Dataset, sds: xr.Dataset, config: YAMLConfig) -> torch.Tensor:

--- a/graph_weather/predict/wb_predict.py
+++ b/graph_weather/predict/wb_predict.py
@@ -121,16 +121,8 @@ def predict(config: YAMLConfig, checkpoint_relpath: str) -> None:
         checkpoint_relpath: path to the model checkpoint that you want to restore
                             should be relative to your config["output:basedir"]/config["output:checkpoints:ckpt-dir"]
     """
-    # initialize dask cluster
-    cluster: Optional[LocalCluster] = None
-    if config["model:dask:enabled"]:
-        LOGGER.debug("Initializing Dask cluster ...")
-        cluster = init_dask_cluster(config)
-    dask_scheduler_address = cluster.scheduler_address if cluster is not None else None
-    LOGGER.debug("Dask scheduler address: %s", dask_scheduler_address)
-
     # create data module (data loaders and data sets)
-    dmod = WeatherBenchTestDataModule(config, scheduler_address=dask_scheduler_address)
+    dmod = WeatherBenchTestDataModule(config)
 
     # number of variables (features)
     num_features = dmod.ds_test.nlev * dmod.ds_test.nvar

--- a/graph_weather/predict/wb_predict.py
+++ b/graph_weather/predict/wb_predict.py
@@ -122,8 +122,10 @@ def predict(config: YAMLConfig, checkpoint_relpath: str) -> None:
                             should be relative to your config["output:basedir"]/config["output:checkpoints:ckpt-dir"]
     """
     # initialize dask cluster
-    LOGGER.debug("Initializing Dask cluster ...")
-    cluster: Optional[LocalCluster] = init_dask_cluster(config) if config["model:dask:enabled"] else None
+    cluster: Optional[LocalCluster] = None
+    if config["model:dask:enabled"]:
+        LOGGER.debug("Initializing Dask cluster ...")
+        cluster = init_dask_cluster(config)
     dask_scheduler_address = cluster.scheduler_address if cluster is not None else None
     LOGGER.debug("Dask scheduler address: %s", dask_scheduler_address)
 

--- a/graph_weather/train/wb_train.py
+++ b/graph_weather/train/wb_train.py
@@ -93,8 +93,8 @@ def train(config: YAMLConfig) -> None:
         logger=logger,
         log_every_n_steps=config["output:logging:log-interval"],
         # run fewer batches per epoch (helpful when debugging)
-        limit_train_batches=config["model:limit-train-batches"],
-        limit_val_batches=config["model:limit-val-batches"],
+        limit_train_batches=config["model:limit-batches: train"],
+        limit_val_batches=config["model:limit-batches:validation"],
         # https://pytorch-lightning.readthedocs.io/en/stable/common/trainer.html#fast-dev-run
         # fast_dev_run=config["output:logging:fast-dev-run"],
     )

--- a/graph_weather/train/wb_train.py
+++ b/graph_weather/train/wb_train.py
@@ -1,16 +1,13 @@
-# Train GNN model on the WeatherBench dataset
-from typing import Optional
+# Train a GNN model on the WeatherBench dataset
 import argparse
 import datetime as dt
 import os
 
-from dask.distributed import LocalCluster
 import pytorch_lightning as pl
 from pytorch_lightning.loggers import WandbLogger, TensorBoardLogger
 from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
 
-from graph_weather.utils.dask_utils import init_dask_cluster
 from graph_weather.utils.config import YAMLConfig
 from graph_weather.data.wb_datamodule import WeatherBenchTrainingDataModule
 from graph_weather.utils.logger import get_logger
@@ -25,18 +22,12 @@ def train(config: YAMLConfig) -> None:
     Args:
         config: job configuration
     """
-
-    # initialize dask cluster
-    LOGGER.debug("Initializing Dask cluster ...")
-    cluster: Optional[LocalCluster] = init_dask_cluster(config) if config["model:dask:enabled"] else None
-    dask_scheduler_address = cluster.scheduler_address if cluster is not None else None
-    LOGGER.debug("Dask scheduler address: %s", dask_scheduler_address)
-
     # create data module (data loaders and data sets)
-    dmod = WeatherBenchTrainingDataModule(config, scheduler_address=dask_scheduler_address)
+    dmod = WeatherBenchTrainingDataModule(config)
 
     # number of variables (features)
     num_features = dmod.ds_train.nlev * dmod.ds_train.nvar
+
     LOGGER.debug("Number of variables: %d", num_features)
     LOGGER.debug("Number of auxiliary (time-independent) variables: %d", dmod.const_data.nconst)
 

--- a/graph_weather/train/wb_train.py
+++ b/graph_weather/train/wb_train.py
@@ -93,7 +93,7 @@ def train(config: YAMLConfig) -> None:
         logger=logger,
         log_every_n_steps=config["output:logging:log-interval"],
         # run fewer batches per epoch (helpful when debugging)
-        limit_train_batches=config["model:limit-batches: train"],
+        limit_train_batches=config["model:limit-batches:training"],
         limit_val_batches=config["model:limit-batches:validation"],
         # https://pytorch-lightning.readthedocs.io/en/stable/common/trainer.html#fast-dev-run
         # fast_dev_run=config["output:logging:fast-dev-run"],

--- a/graph_weather/train/wb_trainer.py
+++ b/graph_weather/train/wb_trainer.py
@@ -10,7 +10,14 @@ from graph_weather.models.losses import NormalizedMSELoss
 
 class LitGraphForecaster(pl.LightningModule):
     def __init__(
-        self, lat_lons: List, feature_dim: int, aux_dim: int, hidden_dim: int = 64, num_blocks: int = 3, lr: float = 3e-4
+        self,
+        lat_lons: List,
+        feature_dim: int,
+        aux_dim: int,
+        hidden_dim: int = 64,
+        num_blocks: int = 3,
+        lr: float = 1e-3,
+        rollout: int = 1,
     ) -> None:
         super().__init__()
         self.gnn = GraphWeatherForecaster(
@@ -24,7 +31,9 @@ class LitGraphForecaster(pl.LightningModule):
             num_blocks=num_blocks,
         )
         self.loss = NormalizedMSELoss(feature_variance=np.ones((feature_dim,)), lat_lons=lat_lons)
+        self.feature_dim = feature_dim
         self.lr = lr
+        self.rollout = rollout
         self.save_hyperparameters()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -32,21 +41,57 @@ class LitGraphForecaster(pl.LightningModule):
 
     def training_step(self, batch: Tuple[torch.Tensor, ...], batch_idx: int) -> torch.Tensor:
         del batch_idx  # not used
-        x, y = batch
-        y_hat = self(x)
-        loss = self.loss(y_hat, y)
-        self.log("train_wmse", loss, on_epoch=True, on_step=True, prog_bar=True, logger=True)
-        return loss
+        assert len(batch) == (self.rollout + 1), "Rollout window doesn't match len(batch)!"
+        train_loss = torch.zeros(1, dtype=batch[0].dtype, device=self.device, requires_grad=False)
+        # start rollout
+        x = batch[0]
+        for rstep in range(self.rollout):
+            y_hat = self(x)  # prediction at rollout step rstep
+            y = batch[rstep + 1]  # target
+            # y includes the auxiliary variables, so we must leave those out when computing the loss
+            train_loss += self.loss(y_hat, y[..., : self.feature_dim])
+            # autoregressive predictions - we re-init the "variable" part of x
+            x[..., : self.feature_dim] = y_hat
+        self.log("train_wmse", train_loss, on_epoch=True, on_step=True, prog_bar=True, logger=True)
+        return train_loss
 
     def validation_step(self, batch: Tuple[torch.Tensor, ...], batch_idx: int) -> torch.Tensor:
-        del batch_idx  # not used
-        x, y = batch
-        with torch.no_grad():
-            y_hat = self(x)
-            val_loss = self.loss(y_hat, y)
-            self.log("val_wmse", val_loss, on_epoch=True, on_step=True, prog_bar=True, logger=True)
+        val_loss = self._shared_eval_step(batch, batch_idx)
+        self.log("val_wmse", val_loss, on_epoch=True, on_step=True, prog_bar=True, logger=True)
         return val_loss
+
+    def test_step(self, batch: Tuple[torch.Tensor, ...], batch_idx: int) -> torch.Tensor:
+        test_loss = self._shared_eval_step(batch, batch_idx)
+        self.log("test_wmse", test_loss, on_epoch=True, on_step=True, prog_bar=True, logger=True)
+        return test_loss
+
+    def predict_step(self, batch: Tuple[torch.Tensor, ...], batch_idx: int) -> torch.Tensor:
+        del batch_idx  # not used
+        preds: List[torch.Tensor] = []
+        with torch.no_grad():
+            # start rollout
+            x = batch[0]
+            for _ in range(self.rollout):
+                y_hat = self(x)
+                x[..., : self.feature_dim] = y_hat
+                preds.append(y_hat)
+        return torch.stack(preds, dim=-1)  # stack along new last dimension
+
+    def _shared_eval_step(self, batch: Tuple[torch.Tensor, ...], batch_idx: int) -> torch.Tensor:
+        del batch_idx
+        assert len(batch) == (self.rollout + 1), "Rollout window doesn't match len(batch)!"
+        loss = torch.zeros(1, dtype=batch[0].dtype, device=self.device, requires_grad=False)
+        with torch.no_grad():
+            # start rollout
+            x = batch[0]
+            for rstep in range(self.rollout):
+                y_hat = self(x)
+                y = batch[rstep + 1]
+                loss += self.loss(y_hat, y[..., : self.feature_dim])
+                x[..., : self.feature_dim] = y_hat
+        return loss
 
     def configure_optimizers(self):
         # TODO: add a learn rate scheduler?
-        return torch.optim.AdamW(self.parameters(), lr=self.lr)
+        return torch.optim.Adam(self.parameters(), betas=(0.0, 0.999), lr=self.lr)
+        # return torch.optim.SGD(self.parameters(), lr=1e-3, momentum=0.9, weight_decay=1e-4)

--- a/graph_weather/utils/constants.py
+++ b/graph_weather/utils/constants.py
@@ -1,0 +1,12 @@
+# An assortment of constants
+
+# chunk size(s) for the xarray WB data
+_DS_TIME_CHUNK = 10
+
+# fixed shapes of the xarray WB data
+_WB_PLEV = 13
+_WB_LAT = 181
+_WB_LON = 360
+
+# ... other stuff
+_DL_PREFETCH_FACTOR = 2

--- a/graph_weather/utils/constants.py
+++ b/graph_weather/utils/constants.py
@@ -1,8 +1,5 @@
 # An assortment of constants
 
-# chunk size(s) for the xarray WB data
-_DS_TIME_CHUNK = 10
-
 # fixed shapes of the xarray WB data
 _WB_PLEV = 13
 _WB_LAT = 181
@@ -10,3 +7,9 @@ _WB_LON = 360
 
 # ... other stuff
 _DL_PREFETCH_FACTOR = 2
+
+# chunk size(s) for the xarray WB data
+_DS_TIME_CHUNK = 10
+
+# netCDF compression level
+_NC_COMPRESS_LEVEL = 9  # max

--- a/graph_weather/utils/constants.py
+++ b/graph_weather/utils/constants.py
@@ -9,7 +9,7 @@ _WB_LON = 360
 _DL_PREFETCH_FACTOR = 2
 
 # chunk size(s) for the xarray WB data
-_DS_TIME_CHUNK = 10
+_DS_TIME_CHUNK = 4
 
 # netCDF compression level
 _NC_COMPRESS_LEVEL = 9  # max

--- a/graph_weather/utils/constants.py
+++ b/graph_weather/utils/constants.py
@@ -6,7 +6,7 @@ _WB_LAT = 181
 _WB_LON = 360
 
 # ... other stuff
-_DL_PREFETCH_FACTOR = 2
+_DL_PREFETCH_FACTOR = 4
 
 # chunk size(s) for the xarray WB data
 _DS_TIME_CHUNK = 4

--- a/graph_weather/utils/constants.py
+++ b/graph_weather/utils/constants.py
@@ -9,7 +9,7 @@ _WB_LON = 360
 _DL_PREFETCH_FACTOR = 4
 
 # chunk size(s) for the xarray WB data
-_DS_TIME_CHUNK = 4
+_DS_TIME_CHUNK = 1
 
 # netCDF compression level
 _NC_COMPRESS_LEVEL = 9  # max

--- a/graph_weather/utils/dask_utils.py
+++ b/graph_weather/utils/dask_utils.py
@@ -1,9 +1,5 @@
-# TODO: replace this with our own dask_utils
 import ctypes
-
 import dask
-from dask.distributed import Client, LocalCluster
-from graph_weather.utils.config import YAMLConfig
 
 
 def __trim_dask_worker_memory() -> int:
@@ -19,11 +15,11 @@ def __trim_dask_worker_memory() -> int:
     return libc.malloc_trim(0)
 
 
-def init_dask_cluster(config: YAMLConfig) -> LocalCluster:
+def init_dask_config(temp_dir: str) -> None:
     dask.config.set(
         {
             # temporary directory
-            "temporary_directory": config["model:dask:temp-dir"],
+            "temporary_directory": temp_dir,
             # this high initial guess tells the scheduler to spread tasks
             # "distributed.scheduler.unknown-task-duration": "10s",
             # worker memory management
@@ -34,16 +30,3 @@ def init_dask_cluster(config: YAMLConfig) -> LocalCluster:
             "distributed.worker.use-file-locking": False,
         }
     )
-    return LocalCluster(
-        n_workers=config["model:dask:num-workers"],
-        threads_per_worker=config["model:dask:num-threads-per-worker"],
-        dashboard_address=f":{config['model:dask:dashboard-port']}",
-        scheduler_port=config["model:dask:scheduler-port"],
-    )
-
-
-def init_dask_client(scheduler_addr: str, config: YAMLConfig) -> Client:
-    client = Client(scheduler_addr)
-    if config["model:dask:trim-worker-memory"]:
-        client.run(__trim_dask_worker_memory)
-    return client

--- a/graph_weather/utils/dask_utils.py
+++ b/graph_weather/utils/dask_utils.py
@@ -25,6 +25,7 @@ def init_dask_cluster(config: YAMLConfig) -> LocalCluster:
         n_workers=config["model:dask:num-workers"],
         threads_per_worker=config["model:dask:num-threads-per-worker"],
         dashboard_address=f":{config['model:dask:dashboard-port']}",
+        scheduler_port=config["model:dask:scheduler-port"],
     )
 
 

--- a/graph_weather/utils/dask_utils.py
+++ b/graph_weather/utils/dask_utils.py
@@ -25,12 +25,13 @@ def init_dask_cluster(config: YAMLConfig) -> LocalCluster:
             # temporary directory
             "temporary_directory": config["model:dask:temp-dir"],
             # this high initial guess tells the scheduler to spread tasks
-            "distributed.scheduler.unknown-task-duration": "10s",
+            # "distributed.scheduler.unknown-task-duration": "10s",
             # worker memory management
             "distributed.worker.memory.spill": 0.9,
             "distributed.worker.memory.target": 0.85,
             "distributed.worker.memory.pause": 0.95,
             "distributed.worker.memory.terminate": False,
+            "distributed.worker.use-file-locking": False,
         }
     )
     return LocalCluster(

--- a/graph_weather/utils/dask_utils.py
+++ b/graph_weather/utils/dask_utils.py
@@ -20,7 +20,19 @@ def __trim_dask_worker_memory() -> int:
 
 
 def init_dask_cluster(config: YAMLConfig) -> LocalCluster:
-    dask.config.set({"temporary_directory": config["model:dask:temp-dir"]})
+    dask.config.set(
+        {
+            # temporary directory
+            "temporary_directory": config["model:dask:temp-dir"],
+            # this high initial guess tells the scheduler to spread tasks
+            "distributed.scheduler.unknown-task-duration": "10s",
+            # worker memory management
+            "distributed.worker.memory.spill": 0.9,
+            "distributed.worker.memory.target": 0.85,
+            "distributed.worker.memory.pause": 0.95,
+            "distributed.worker.memory.terminate": False,
+        }
+    )
     return LocalCluster(
         n_workers=config["model:dask:num-workers"],
         threads_per_worker=config["model:dask:num-threads-per-worker"],

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     entry_points={
         "console_scripts": [
             "gnn-wb-train=graph_weather.train.wb_train:main",
+            "gnn-wb-predict=graph_weather.predict.wb_predict:main",
         ]
     },
 )

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -141,25 +141,16 @@ class DataloaderTests(unittest.TestCase):
 
         dl_test = DataLoader(
             ds_test,
-            # we're putting together one full batch from this many batch-chunks
-            # this means the "real" batch size == config["model:dataloader:batch-size"] * config["model:dataloader:batch-chunk-size"]
             batch_size=BATCH_SIZE,
-            # number of worker processes
             num_workers=NUM_WORKERS,
-            # use of pinned memory can speed up CPU-to-GPU data transfers
-            # see https://pytorch.org/docs/stable/notes/cuda.html#cuda-memory-pinning
             pin_memory=True,
-            # custom collator (see above)
             collate_fn=test_batch_collator,
-            # worker initializer
             worker_init_fn=partial(
                 worker_init_func,
                 num_dask_workers=1,
                 num_dask_threads_per_worker=1,
             ),
-            # prefetch batches (default prefetch_factor == 2)
             prefetch_factor=2,
-            # drop last incomplete batch (makes it easier to test the resulting tensor shapes)
             drop_last=True,
         )
 


### PR DESCRIPTION
Autoregressive prediction with multi-step loss, similar to Keisler (2021).
The rollout window size is defined in the yml config file:

```yaml
# Keisler's three training rounds were:
# Round 1. ~960,000 batches @ ~0.3 seconds per batch (4-step rollout)
# Round 2. ~90,000 batches @ ~1.0 seconds per batch (8-step rollout)
# Round 3. ~70,000 batches @ ~1.5 seconds per batch (12-step rollout)
# Each batch is an N-step rollout, with batch_size=1
rollout: 4
```

The training logic looks as follows:

```python
        batch = ... # tuple (x_{t}, x_{t+dt}, x_{t+2*dt}, ... x_{t + (rollout+1)*dt})
        # start rollout
        x = batch.X[0]
        for rstep in range(self.rollout):
            y_hat = self(x)  # prediction at rollout step rstep
            y = batch.X[rstep + 1]  # target
            # y includes the auxiliary variables, so we must leave those out when computing the loss
            train_loss += self.loss(y_hat, y[..., : self.feature_dim])
            # autoregressive predictions - we re-init the "variable" part of x
            x[..., : self.feature_dim] = y_hat
```

Also: added [activation checkpointing](https://pytorch.org/docs/stable/checkpoint.html) for the GNN MLP layers. This reduces total GPU memory usage significantly, allowing us to train the following configs on a single GPU:

- (`hidden-dim: 64`, `rollout: 12`) - 2.5M model params, batch size = 1
- (`hidden-dim: 128`, `rollout: 8`) - 16M model params, batch size = 1

The "largest" (`hidden-dim: 256`, 120M param) model can't seem to fit on one GPU, even with a rollout window of length 1.

Work is on-going to scale this to multiple GPUs using DDP.