### PR TITLE
Multi-GPU support.

### DIFF
--- a/README_parallel.md
+++ b/README_parallel.md
@@ -1,0 +1,137 @@
+### [Lightning DDP](https://pytorch-lightning.readthedocs.io/en/stable/accelerators/gpu_intermediate.html#distributed-data-parallel)
+
+DDP works as follows:
+
+1. Each GPU across each node gets its own process.
+2. Each GPU gets visibility into a subset of the overall dataset. It will only ever see that subset.
+3. Each process inits the model.
+4. Each process performs a full forward and backward pass in parallel.
+5. The gradients are synced and averaged across all processes.
+6. Each process updates its optimizer.
+
+With Dask, it's important to make sure that only the "root" process sets up the cluster, the others just create their own clients.
+Otherwise we end up with multiple Dask clusters. 
+
+With DDP the model doesn't need to be pickled (so there are no pickle-related limitations).
+
+**Q**: OK to have one Dask cluster per node? Would this be more efficient?
+
+The Lightning implementation of DDP calls your script under the hood multiple times with the correct environment variables:
+
+```shell
+# example for 3 GPUs DDP
+MASTER_ADDR=localhost MASTER_PORT=random() WORLD_SIZE=3 NODE_RANK=0 LOCAL_RANK=0 python my_file.py --accelerator 'gpu' --devices 3 --etc
+MASTER_ADDR=localhost MASTER_PORT=random() WORLD_SIZE=3 NODE_RANK=1 LOCAL_RANK=0 python my_file.py --accelerator 'gpu' --devices 3 --etc
+MASTER_ADDR=localhost MASTER_PORT=random() WORLD_SIZE=3 NODE_RANK=2 LOCAL_RANK=0 python my_file.py --accelerator 'gpu' --devices 3 --etc
+```
+
+DDP _cannot_ be used:
+
+- in a Jupyter Notebook, Google COLAB, Kaggle, etc.
+- in a nested script without a root package
+
+DDP variants and tradeoffs: https://pytorch-lightning.readthedocs.io/en/stable/accelerators/gpu_intermediate.html?highlight=DDP#comparison-of-ddp-variants-and-tradeoffs
+
+#### DDP **optimizations**:
+
+https://pytorch-lightning.readthedocs.io/en/stable/advanced/model_parallel.html#ddp-optimizations
+
+
+### Debugging
+
+To debug a distributed model, debug it locally by running the distributed version on CPUs:
+
+```python
+trainer = Trainer(accelerator="cpu", strategy="ddp", devices=2)
+```
+
+On the CPU, you can use `pdb` or `breakpoint()` or use regular print statements.
+
+```python
+class LitModel(LightningModule):
+    def training_step(self, batch, batch_idx):
+
+        debugging_message = ...
+        print(f"RANK - {self.trainer.global_rank}: {debugging_message}")
+
+        if self.trainer.global_rank == 0:
+            import pdb
+            pdb.set_trace()
+
+        # to prevent other processes from moving forward until all processes are in sync
+        self.trainer.strategy.barrier()
+```
+
+### Batch size
+
+When using distributed training make sure to modify your learning rate according to your effective batch size.
+Let’s say you have a batch size of 7 in your dataloader.
+
+```python
+class LitModel(LightningModule):
+    def train_dataloader(self):
+        return Dataset(..., batch_size=7)
+```
+
+In `DDP`, `DDP_SPAWN`, `Deepspeed`, `DDP_SHARDED`, or Horovod your effective batch size will be `7 * devices * num_nodes`.
+
+### [Lightning `global_rank`](https://pytorch-lightning.readthedocs.io/en/stable/common/lightning_module.html#global-rank)
+
+The `global_rank` is the index of the current process across all nodes and devices. 
+Lightning will perform some operations such as logging, weight checkpointing only when `global_rank=0`. 
+You usually do not need to use this property, but it is useful to know how to access it if needed.
+
+```python
+def training_step(self, batch, batch_idx):
+    if self.global_rank == 0:
+        # do something only once across all the nodes
+        ...
+```
+
+### [Validation with DDP](https://pytorch-lightning.readthedocs.io/en/stable/common/lightning_module.html#validation)
+
+It is recommended to validate on single device to ensure each sample/batch gets evaluated exactly once. 
+This is helpful to make sure benchmarking for research papers is done the right way. 
+Otherwise, in a multi-device setting, samples could occur duplicated when `DistributedSampler` is used, for eg. with `strategy="ddp"`.
+It replicates some samples on some devices to make sure all devices have same batch size in case of uneven inputs.
+
+### Logging with DDP
+
+- https://github.com/Lightning-AI/lightning/discussions/6501
+
+`LightningModule` -> `self.log` set `rank_zero_only == True` to make sure the value will be logged only on rank 0.
+This will prevent synchronization which would produce a deadlock as not all processes would perform this log call.
+
+What about:
+
+- `sync_dist (bool)` – if True, reduces the metric across GPUs/TPUs. Use with care as this may lead to a significant communication overhead.
+- `sync_dist_group` (Optional[Any]) – the DDP group to sync across.
+
+### Advanced techniques (sharding, etc.)
+
+- https://pytorch-lightning.readthedocs.io/en/stable/advanced/model_parallel.html#sharded-training
+- https://github.com/Lightning-AI/lightning/issues/6047
+- https://github.com/Lightning-AI/lightning/discussions/8795
+- https://engineering.fb.com/2021/07/15/open-source/fsdp/
+
+
+### In-memory datasets
+
+Say you want to use an in-memory dataset and you have no alternative. Then putting it in shared memory is definitely the best approach
+
+1. Just avoid putting the logic in `setup()`. This hook runs in every process, so not desired for this use case.
+2. Use a strategy like `ddp_spawn` or `ddp_fork`
+3. Load and process your data in the main process (i.e., before calling `trainer.fit`).
+4. Give the pointer to the in-memory dataset to your dataset/dataloader
+5. After processes spawn, they inherit the memory and the training in the worker processes will reference this shared data
+
+Docs: https://pytorch-lightning.readthedocs.io/en/stable/advanced/training_tricks.html?highlight=Sharing%20Datasets%20Across%20Process%20Boundaries#sharing-datasets-across-process-boundaries
+
+A GNN example:
+
+https://github.com/pyg-team/pytorch_geometric/blob/master/examples/pytorch_lightning/gin.py
+
+Plus:
+
+1. Their dataset: https://github.com/pyg-team/pytorch_geometric/blob/ab78d47f134ec467129136affa7379a567ca5e9f/torch_geometric/datasets/tu_dataset.py#L12
+2. A generic `InMemoryDataset`: https://github.com/pyg-team/pytorch_geometric/blob/ab78d47f134ec467129136affa7379a567ca5e9f/torch_geometric/data/in_memory_dataset.py#L13

--- a/graph_weather/config/wb_config_atos.yaml
+++ b/graph_weather/config/wb_config_atos.yaml
@@ -87,7 +87,7 @@ model:
   # runs only N training batches [N = integer | null]
   # if null then we run through all the batches
   limit-batches:
-    training: 50
+    training: null
     validation: null
     test: 50
     predict: 50
@@ -95,7 +95,7 @@ model:
   # parallel strategy [set to null if you're running on a single node, single device]
   # see here for the various options:
   # https://pytorch-lightning.readthedocs.io/en/stable/extensions/strategy.html
-  strategy: null  # ddp_find_unused_parameters_false
+  strategy: ddp_find_unused_parameters_false  # null
 
   # number of GPUs per node and number of nodes (for DDP)
   num-gpus: 1

--- a/graph_weather/config/wb_config_atos.yaml
+++ b/graph_weather/config/wb_config_atos.yaml
@@ -1,20 +1,20 @@
 input:
-  format: zarr  # or "netcdf4"
+  format: netcdf4  # "zarr" or "netcdf4"
   variables:
     training:
-      # basedir: /ec/res4/hpcperm/syma/WeatherBench/netcdf/training
-      # filename-template: "pl_*.nc"
-      basedir: /ec/res4/scratch/syma/data/WeatherBench/zarr/training
-      filename-template: "pl_*.zarr"
+      basedir: /ec/res4/hpcperm/syma/WeatherBench/netcdf/training
+      filename-template: "pl_*.nc"
+      # basedir: /ec/res4/scratch/syma/data/WeatherBench/zarr/training
+      # filename-template: "pl_*.zarr"
       summary-stats:
         precomputed: True
         means: /ec/res4/hpcperm/syma/WeatherBench/netcdf/means-1979-2015.nc
         std-devs: /ec/res4/hpcperm/syma/WeatherBench/netcdf/sds-1979-2015.nc
     validation:
-      # basedir: /ec/res4/hpcperm/syma/WeatherBench/netcdf/validation
-      # filename-template: "pl_*.nc"
-      basedir: /ec/res4/scratch/syma/data/WeatherBench/zarr/validation
-      filename-template: "pl_*.zarr"
+      basedir: /ec/res4/hpcperm/syma/WeatherBench/netcdf/validation
+      filename-template: "pl_*.nc"
+      # basedir: /ec/res4/scratch/syma/data/WeatherBench/zarr/validation
+      # filename-template: "pl_*.zarr"
     test:
       basedir: /ec/res4/hpcperm/syma/WeatherBench/netcdf/test
       filename-template: "pl_*.nc"
@@ -40,7 +40,7 @@ input:
 output:
   basedir: /ec/res4/scratch/syma/GNN/WeatherBench
   logging:
-    log-dir: /ec/res4/scratch/syma/GNN/WeatherBench/logs
+    log-dir: logs
     log-interval: 25
   checkpoints:
     ckpt-dir: checkpoints
@@ -56,13 +56,12 @@ model:
     # this will detect and trace back NaNs / Infs etc. but will slow down training
     anomaly-detection: False
   wandb:
-    enabled: False
+    enabled: True
   tensorboard:
     enabled: False
   dask:
     enabled: True
-    temp-dir: /ec/res4/scratch/syma/GNN/WeatherBench/dask-temp-dir
-    log-dir: /ec/res4/scratch/syma/GNN/WeatherBench/dask-log-dir
+    temp-dir: dask-temp-dir
     trim-worker-memory: True
     num-workers: 8
     num-threads-per-worker: 1
@@ -70,15 +69,17 @@ model:
     scheduler-port: 8786
   dataloader:
     num-workers:
-      training: 4
-      validation: 2
+      training: 6
+      validation: 8
       inference: 4
     batch-size:
       training: 1
-      inference: 2
+      validation: 1
+      inference: 1
     batch-chunk-size:
-      training: 1
-      inference: 4
+      training: 2
+      validation: 16
+      inference: 8
 
   # miscellaneous
   precision: 16
@@ -86,10 +87,19 @@ model:
   # runs only N training batches [N = integer | null]
   # if null then we run through all the batches
   limit-batches:
-    training: 200
-    validation: 50
+    training: 50
+    validation: null
     test: 50
     predict: 50
+
+  # parallel strategy [set to null if you're running on a single node, single device]
+  # see here for the various options:
+  # https://pytorch-lightning.readthedocs.io/en/stable/extensions/strategy.html
+  strategy: null  # ddp_find_unused_parameters_false
+
+  # number of GPUs per node and number of nodes (for DDP)
+  num-gpus: 1
+  num-nodes: 1
 
   # specific GNN model settings
   lead-time: 6
@@ -98,7 +108,7 @@ model:
   hidden-dim: 64
   num-blocks: 3
   # length of the "rollout" window (see Keisler's paper)
-  rollout: 4
+  rollout: 12
   # Keisler's three training rounds were:
   # Round 1. ~960,000 batches @ ~0.3 seconds per batch (4-step rollout)
   # Round 2. ~90,000 batches @ ~1.0 seconds per batch (8-step rollout)

--- a/graph_weather/data/wb_constants.py
+++ b/graph_weather/data/wb_constants.py
@@ -9,7 +9,6 @@ class WeatherBenchConstantFields:
         self,
         const_fname: str,
         const_names: Optional[List[str]] = None,
-        batch_chunk_size: int = 4,
     ) -> None:
         """
         Args:
@@ -45,7 +44,6 @@ class WeatherBenchConstantFields:
         )
 
         self._constants = np.concatenate([self._constants, self.X_latlon], axis=-1)
-        self._constants = np.stack([self._constants for _ in range(batch_chunk_size)], axis=0)  # batch axis
 
         # reshape the latlon info into what the GNN expects
         self._latlons = np.array([lats, lons]).T.reshape((-1, 2))
@@ -53,12 +51,11 @@ class WeatherBenchConstantFields:
         # number of constant arrays
         self._nconst = self._constants.shape[-1]
 
-    @property
-    def constants(self):
+    def get_constants(self, batch_chunk_size: int) -> np.ndarray:
         """
         Returns the constant data as a numpy array of shape (batch_chunk_size, lat, lon, nvar)
         """
-        return self._constants
+        return np.stack([self._constants for _ in range(batch_chunk_size)], axis=0)  # batch axis
 
     @property
     def latlons(self):

--- a/graph_weather/data/wb_datamodule.py
+++ b/graph_weather/data/wb_datamodule.py
@@ -175,6 +175,7 @@ class WeatherBenchTrainingDataModule(pl.LightningDataModule):
 
     def _load_summary_statistics(self) -> Tuple[xr.Dataset, xr.Dataset]:
         # load pre-computed means and standard deviations
+        var_names = self.config["input:variables:names"]
         var_means = xr.load_dataset(
             os.path.join(
                 self.config["input:variables:training:basedir"], self.config["input:variables:training:summary-stats:means"]
@@ -185,7 +186,7 @@ class WeatherBenchTrainingDataModule(pl.LightningDataModule):
                 self.config["input:variables:training:basedir"], self.config["input:variables:training:summary-stats:std-devs"]
             )
         )
-        return var_means, var_sds
+        return var_means[var_names], var_sds[var_names]
 
     def _get_dataloader(self, data: xr.Dataset, num_workers: int, batch_size: int, batch_chunk_size: int) -> DataLoader:
         return DataLoader(

--- a/graph_weather/data/wb_datamodule.py
+++ b/graph_weather/data/wb_datamodule.py
@@ -95,10 +95,18 @@ def get_weatherbench_dataset(
 class WeatherBenchTrainingDataModule(pl.LightningDataModule):
     def __init__(self, config: YAMLConfig) -> None:
         super().__init__()
-        self.batch_size = config["model:dataloader:batch-size:training"]
+        self.bs_train = config["model:dataloader:batch-size:training"]
+        self.bs_val = config["model:dataloader:batch-size:validation"]
+
+        self.bcs_train = config["model:dataloader:batch-chunk-size:training"]
+        self.bcs_val = config["model:dataloader:batch-chunk-size:validation"]
+
         self.num_workers_train = config["model:dataloader:num-workers:training"]
         self.num_workers_val = config["model:dataloader:num-workers:validation"]
         self.config = config
+        # TODO: is this the right variable to query here?
+        self.local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+        LOGGER.debug("Our WeatherBenchTrainingDataModule object with id = %s has LOCAL_RANK = %d", id(self), self.local_rank)
 
         if config["input:variables:training:summary-stats:precomputed"]:
             var_means, var_sds = self._load_summary_statistics()
@@ -118,6 +126,9 @@ class WeatherBenchTrainingDataModule(pl.LightningDataModule):
             lead_time=config["model:lead-time"],
             batch_chunk_size=config["model:dataloader:batch-chunk-size:training"],
             rollout=config["model:rollout"],
+            rank=self.local_rank,
+            # TODO: what if we want to scale to more than one node? the world_size can be larger, right?
+            world_size=config["model:num-gpus"] * config["model:num-nodes"],
         )
 
         self.ds_valid = WeatherBenchDataset(
@@ -130,14 +141,15 @@ class WeatherBenchTrainingDataModule(pl.LightningDataModule):
             var_sd=var_sds,
             plevs=config["input:variables:levels"],
             lead_time=config["model:lead-time"],
-            batch_chunk_size=config["model:dataloader:batch-chunk-size:training"],
+            batch_chunk_size=config["model:dataloader:batch-chunk-size:validation"],
             rollout=config["model:rollout"],
+            rank=self.local_rank,
+            world_size=config["model:num-gpus"],
         )
 
         self.const_data = WeatherBenchConstantFields(
             const_fname=config["input:constants:filename"],
             const_names=config["input:constants:names"],
-            batch_chunk_size=config["model:dataloader:batch-chunk-size:training"],
         )
 
     def _calculate_summary_statistics(self) -> Tuple[xr.Dataset, xr.Dataset]:
@@ -175,23 +187,23 @@ class WeatherBenchTrainingDataModule(pl.LightningDataModule):
         )
         return var_means, var_sds
 
-    def _get_dataloader(self, data: xr.Dataset, num_workers: int) -> DataLoader:
+    def _get_dataloader(self, data: xr.Dataset, num_workers: int, batch_size: int, batch_chunk_size: int) -> DataLoader:
         return DataLoader(
             data,
             # we're putting together one full batch from this many batch-chunks
             # this means the "real" batch size == config["model:dataloader:batch-size"] * config["model:dataloader:batch-chunk-size"]
-            batch_size=self.batch_size,
+            batch_size=batch_size,
             # number of worker processes
             num_workers=num_workers,
             # use of pinned memory can speed up CPU-to-GPU data transfers
             # see https://pytorch.org/docs/stable/notes/cuda.html#cuda-memory-pinning
             pin_memory=True,
             # custom collator (see above)
-            collate_fn=_custom_collator_wrapper(self.const_data.constants),
+            collate_fn=_custom_collator_wrapper(self.const_data.get_constants(batch_chunk_size)),
             # worker initializer
             worker_init_fn=partial(
                 worker_init_func,
-                dask_temp_dir=self.config["model:dask:temp-dir"],
+                dask_temp_dir=os.path.join(self.config["output:basedir"], self.config["model:dask:temp-dir"]),
                 num_dask_workers=self.config["model:dask:num-workers"],
                 num_dask_threads_per_worker=self.config["model:dask:num-threads-per-worker"],
             ),
@@ -201,10 +213,10 @@ class WeatherBenchTrainingDataModule(pl.LightningDataModule):
         )
 
     def train_dataloader(self) -> DataLoader:
-        return self._get_dataloader(self.ds_train, self.num_workers_train)
+        return self._get_dataloader(self.ds_train, self.num_workers_train, self.bs_train, self.bcs_train)
 
     def val_dataloader(self) -> DataLoader:
-        return self._get_dataloader(self.ds_valid, self.num_workers_val)
+        return self._get_dataloader(self.ds_valid, self.num_workers_val, self.bs_val, self.bcs_val)
 
     def transfer_batch_to_device(self, batch: WeatherBenchDataBatch, device: torch.device, dataloader_idx: int = 0) -> None:
         del dataloader_idx  # not used
@@ -216,7 +228,8 @@ class WeatherBenchTrainingDataModule(pl.LightningDataModule):
 class WeatherBenchTestDataModule(pl.LightningDataModule):
     def __init__(self, config: YAMLConfig) -> None:
         super().__init__()
-        self.batch_size = config["model:dataloader:batch-size:inference"]
+        self.bs = config["model:dataloader:batch-size:inference"]
+        self.bcs = config["model:dataloader:batch-chunk-size:inference"]
         self.num_workers = config["model:dataloader:num-workers:inference"]
         self.config = config
 
@@ -278,13 +291,13 @@ class WeatherBenchTestDataModule(pl.LightningDataModule):
     def _get_dataloader(self, data: xr.Dataset) -> DataLoader:
         return DataLoader(
             data,
-            batch_size=self.batch_size,
+            batch_size=self.bs,
             num_workers=self.num_workers,
             pin_memory=True,
-            collate_fn=_custom_collator_wrapper(self.const_data.constants),
+            collate_fn=_custom_collator_wrapper(self.const_data.get_constants(self.bcs)),
             worker_init_fn=partial(
                 worker_init_func,
-                dask_temp_dir=self.config["model:dask:temp-dir"],
+                dask_temp_dir=os.path.join(self.config["output:basedir"], self.config["model:dask:temp-dir"]),
                 num_dask_workers=self.config["model:dask:num-workers"],
                 num_dask_threads_per_worker=self.config["model:dask:num-threads-per-worker"],
             ),

--- a/graph_weather/train/utils.py
+++ b/graph_weather/train/utils.py
@@ -1,0 +1,38 @@
+from typing import Union
+import os
+import argparse
+
+from pytorch_lightning.loggers import WandbLogger, TensorBoardLogger
+
+from graph_weather.utils.config import YAMLConfig
+
+
+def build_pl_logger(config: YAMLConfig) -> Union[WandbLogger, TensorBoardLogger, bool]:
+    # init logger
+    if config["model:wandb:enabled"]:
+        # use weights-and-biases
+        return WandbLogger(
+            project="GNN-WB",
+            save_dir=os.path.join(
+                config["output:basedir"],
+                config["output:logging:log-dir"],
+            ),
+        )
+    elif config["model:tensorboard:enabled"]:
+        # use tensorboard
+        return TensorBoardLogger(
+            os.path.join(
+                config["output:basedir"],
+                config["output:logging:log-dir"],
+            ),
+            name="gnn_train_logs",
+        )
+    return False
+
+
+def get_args() -> argparse.Namespace:
+    """Returns a namespace containing the command line arguments"""
+    parser = argparse.ArgumentParser()
+    required_args = parser.add_argument_group("required arguments")
+    required_args.add_argument("--config", required=True, help="Model configuration file (YAML)")
+    return parser.parse_args()

--- a/graph_weather/train/wb_persistence.py
+++ b/graph_weather/train/wb_persistence.py
@@ -101,6 +101,8 @@ def persistence(config: YAMLConfig) -> None:
         limit_val_batches=config["model:limit-batches:validation"],
     )
 
+    # Don't call train() - it won't work (there is nothing to train here).
+    # Instead, use validate() or test() to get the baseline WMSEs.
     trainer.validate(model, datamodule=dmod)
 
     LOGGER.debug("---- DONE. ----")

--- a/graph_weather/train/wb_persistence.py
+++ b/graph_weather/train/wb_persistence.py
@@ -1,0 +1,113 @@
+from typing import Tuple, List
+
+import numpy as np
+import torch
+import pytorch_lightning as pl
+
+from graph_weather.models.losses import NormalizedMSELoss
+from graph_weather.data.wb_datamodule import WeatherBenchDataBatch
+from graph_weather.train.utils import build_pl_logger, get_args
+from graph_weather.utils.config import YAMLConfig
+from graph_weather.utils.logger import get_logger
+from graph_weather.data.wb_datamodule import WeatherBenchTrainingDataModule
+
+LOGGER = get_logger(__name__)
+
+
+class LitPersistenceForecaster(pl.LightningModule):
+    """
+    Dummy Trainer that implements atmospheric persistence (forecasts that target == input).
+    Use this to produce a simple baseline value for the "real" training / validation loss.
+    """
+
+    def __init__(
+        self,
+        lat_lons: List,
+        feature_dim: int,
+        rollout: int = 1,
+    ) -> None:
+        super().__init__()
+        self.loss = NormalizedMSELoss(feature_variance=np.ones((feature_dim,)), lat_lons=lat_lons)
+        self.feature_dim = feature_dim
+        self.rollout = rollout
+        self.save_hyperparameters()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Persistence: returns (a subset of) x"""
+        return x[..., : self.feature_dim]
+
+    def training_step(self, batch: WeatherBenchDataBatch, batch_idx: int) -> None:
+        del batch, batch_idx  # not used
+        raise NotImplementedError
+
+    def validation_step(self, batch: WeatherBenchDataBatch, batch_idx: int) -> torch.Tensor:
+        val_loss = self._shared_eval_step(batch, batch_idx)
+        self.log("val_wmse", val_loss, on_epoch=True, on_step=True, prog_bar=True, logger=True, batch_size=batch.X[0].shape[0])
+        return val_loss
+
+    def test_step(self, batch: WeatherBenchDataBatch, batch_idx: int) -> torch.Tensor:
+        test_loss = self._shared_eval_step(batch, batch_idx)
+        self.log("test_wmse", test_loss, on_epoch=True, on_step=True, prog_bar=True, logger=True, batch_size=batch.X[0].shape[0])
+        return test_loss
+
+    def _shared_eval_step(self, batch: WeatherBenchDataBatch, batch_idx: int) -> torch.Tensor:
+        del batch_idx
+        loss = torch.zeros(1, dtype=batch.X[0].dtype, device=self.device, requires_grad=False)
+        with torch.no_grad():
+            # start rollout
+            x = batch.X[0]
+            for rstep in range(self.rollout):
+                y_hat = self(x)
+                y = batch.X[rstep + 1]
+                loss += self.loss(y_hat, y[..., : self.feature_dim])
+        return loss
+
+    def configure_optimizers(self):
+        return None
+
+
+def persistence(config: YAMLConfig) -> None:
+    """
+    Train entry point.
+    Args:
+        config: job configuration
+    """
+    # create data module (data loaders and data sets)
+    dmod = WeatherBenchTrainingDataModule(config)
+
+    # number of variables (features)
+    num_features = dmod.ds_train.nlev * dmod.ds_train.nvar
+
+    LOGGER.debug("Number of variables: %d", num_features)
+    LOGGER.debug("Number of auxiliary (time-independent) variables: %d", dmod.const_data.nconst)
+
+    model = LitPersistenceForecaster(
+        lat_lons=dmod.const_data.latlons,
+        feature_dim=num_features,
+        rollout=config["model:rollout"],
+    )
+
+    trainer = pl.Trainer(
+        accelerator="gpu",  # can run on the CPU, too - but it'll be slower (the GPU will speed up the loss computations)
+        detect_anomaly=False,
+        strategy=None,
+        devices=1,
+        num_nodes=1,
+        precision=config["model:precision"],
+        max_epochs=config["model:max-epochs"],
+        logger=build_pl_logger(config),
+        log_every_n_steps=config["output:logging:log-interval"],
+        limit_train_batches=config["model:limit-batches:training"],
+        limit_val_batches=config["model:limit-batches:validation"],
+    )
+
+    trainer.validate(model, datamodule=dmod)
+
+    LOGGER.debug("---- DONE. ----")
+
+
+def main() -> None:
+    """Entry point for training."""
+    args = get_args()
+    config = YAMLConfig(args.config)
+    persistence(config)

--- a/graph_weather/utils/dask_utils.py
+++ b/graph_weather/utils/dask_utils.py
@@ -2,7 +2,7 @@ import ctypes
 import dask
 
 
-def __trim_dask_worker_memory() -> int:
+def trim_dask_worker_memory() -> int:
     """
     Manually trim Dask worker memory. This will forcefully release allocated but unutilized memory.
     This may help reduce total memory used per worker.
@@ -22,11 +22,17 @@ def init_dask_config(temp_dir: str) -> None:
             "temporary_directory": temp_dir,
             # this high initial guess tells the scheduler to spread tasks
             # "distributed.scheduler.unknown-task-duration": "10s",
-            # worker memory management
-            "distributed.worker.memory.spill": 0.9,
+            # worker memory management:
+            # target - fraction of managed memory where we start spilling to disk
             "distributed.worker.memory.target": 0.85,
+            # spill - fraction of process memory where we start spilling to disk
+            "distributed.worker.memory.spill": 0.9,
+            # pause - fraction of process memory at which we pause worker threads
             "distributed.worker.memory.pause": 0.95,
+            # terminate - fraction of process memory at which we terminate the worker
             "distributed.worker.memory.terminate": False,
             "distributed.worker.use-file-locking": False,
+            # MALLOC_TRIM_THRESHOLD_ - aggressively trim memory
+            "distributed.nanny.environ.MALLOC_TRIM_THRESHOLD_": 0,
         }
     )

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     entry_points={
         "console_scripts": [
             "gnn-wb-train=graph_weather.train.wb_train:main",
+            "gnn-wb-persistence=graph_weather.train.wb_persistence:main",
             "gnn-wb-predict=graph_weather.predict.wb_predict:main",
         ]
     },


### PR DESCRIPTION
1/ Multi-GPU support. Single or multi-node using distributed data parallel (DDP) and NCCL.
Most relevant config settings:
```yaml
  # parallel strategy [set to null if you're running on a single node, single device]
  # see here for the various options:
  # https://pytorch-lightning.readthedocs.io/en/stable/extensions/strategy.html
  strategy:  ddp_find_unused_parameters_false  # null

  # number of GPUs per node and number of nodes (for DDP)
  num-gpus: 1
  num-nodes: 1
```
NB: the "base" learning rate (in the config file) will be multiplied by the total device count.

2/ Persistence (to be used as a WMSE baseline)